### PR TITLE
Updated shebang to respect local config

### DIFF
--- a/ats.py
+++ b/ats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import requests
 import hmac
 import argparse


### PR DESCRIPTION
The python3 executable on my machine is not at /usr/bin/python, so updated this script to use the system-configured python3 instead.